### PR TITLE
Extend type of props according to whole prop types of vue3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,10 +166,10 @@ function vuelve<
             // Check if the property has the required: true property
             if (prop.required === true) {
               throw new Error(`${propKey} is required but not provided.`)
-            } else {
+            } else if(isPropOptions(prop)) {
               props = {
                 ...props,
-                [propKey]: undefined,
+                [propKey]: prop.default,
               }
             }
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,6 @@ function vuelve<
           // Check argument type is correct
           if (propKey && propType) {
             if (isPropOptions(propType)) {
-              console.log(propType.type)
               if (typeof propType.type == 'function' && arg.constructor.name !== propType.type.name) {
                 throw new TypeError(
                   `Invalid prop: type check failed for prop "${propKey}". Expected ${propType.type?.constructor.name}, got ${arg.constructor.name}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ function vuelve<
             if (isPropOptions(propType)) {
               if (typeof propType.type == 'function' && arg.constructor.name !== propType.type.name) {
                 throw new TypeError(
-                  `Invalid prop: type check failed for prop "${propKey}". Expected ${propType.type?.constructor.name}, got ${arg.constructor.name}`
+                  `Invalid prop: type check failed for prop "${propKey}". Expected ${propType.type?.name}, got ${arg.constructor.name}`
                 )
               }
             } else if (arg.constructor.name !== propType.name) {
@@ -158,17 +158,24 @@ function vuelve<
       })
       if (Object.keys(composable.props).length > args.length) {
         Object.keys(composable.props)
-          .slice(args.length - 1)
+          .slice(args.length)
           .forEach((propKey, i) => {
             const prop = getPropType(i)
 
             // Check if the property has the required: true property
             if (prop.required === true) {
               throw new Error(`${propKey} is required but not provided.`)
-            } else if(isPropOptions(prop)) {
-              props = {
-                ...props,
-                [propKey]: prop.default,
+            } else if (isPropOptions(prop)) {
+              if (typeof prop.default == 'function') {
+                props = {
+                  ...props,
+                  [propKey]: prop.default(),
+                }
+              } else {
+                props = {
+                  ...props,
+                  [propKey]: prop.default,
+                }
               }
             }
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,11 @@ import {
   ComputedRef,
   MethodOptions,
   ComputedOptions,
+  ComponentObjectPropsOptions,
   Ref,
 } from 'vue'
 import cloneDeep from 'lodash.clonedeep'
-import { isArray, isFunction } from './utils.ts'
+import { isArray, isFunction, isPropOptions } from './utils.ts'
 import {
   ComposableArrayProps,
   ComposableContext,
@@ -46,7 +47,6 @@ type Composable<
       ComposableObjectProps<Props, Data, Computed, Methods>,
       ComposableContext<Props, Data, Computed, Methods, Args>
     >
-
 function vuelve<
   Props = {},
   Data = {},
@@ -74,7 +74,7 @@ function vuelve<
 ): (...args: Args) => ComposableReturn<Data, Computed, Methods, Args>
 
 function vuelve<
-  Props = {},
+  Props extends ComponentObjectPropsOptions = {},
   Data = {},
   Computed extends ComputedOptions = {},
   Methods extends MethodOptions = {},
@@ -95,7 +95,7 @@ function vuelve<
   Args extends any[] = any[]
 >(composable: Composable<PropNames, Props, Data, Computed, Methods, Args>) {
   return function setup(...args: Args) {
-    let props = {} as Record<string, Ref<any>>
+    let props = {} as Record<string, Ref<any> | undefined>
     let data = {} as Record<string, Ref<any>>
     let methods = {} as Record<string, Function>
     let computeds = {} as Record<string, ComputedRef<any>>
@@ -105,7 +105,7 @@ function vuelve<
     if (composable.props) {
       const isComposablePropsArray = isArray(composable.props)
       const propKeys = isComposablePropsArray ? composable.props : Object.keys(composable.props)
-      const getPropType = (key: number) => Object.values(composable.props as object)[key] as Function
+      const getPropType = (key: number) => Object.values(composable.props as object)[key]
 
       args?.forEach((arg, i) => {
         if (isComposablePropsArray) {
@@ -137,7 +137,14 @@ function vuelve<
 
           // Check argument type is correct
           if (propKey && propType) {
-            if (arg.constructor.name !== propType.name) {
+            if (isPropOptions(propType)) {
+              console.log(propType.type)
+              if (typeof propType.type == 'function' && arg.constructor.name !== propType.type.name) {
+                throw new TypeError(
+                  `Invalid prop: type check failed for prop "${propKey}". Expected ${propType.type?.constructor.name}, got ${arg.constructor.name}`
+                )
+              }
+            } else if (arg.constructor.name !== propType.name) {
               throw new TypeError(
                 `Invalid prop: type check failed for prop "${propKey}". Expected ${propType?.name}, got ${arg.constructor.name}`
               )
@@ -150,8 +157,24 @@ function vuelve<
           }
         }
       })
-    }
+      if (Object.keys(composable.props).length > args.length) {
+        Object.keys(composable.props)
+          .slice(args.length - 1)
+          .forEach((propKey, i) => {
+            const prop = getPropType(i)
 
+            // Check if the property has the required: true property
+            if (prop.required === true) {
+              throw new Error(`${propKey} is required but not provided.`)
+            } else {
+              props = {
+                ...props,
+                [propKey]: undefined,
+              }
+            }
+          })
+      }
+    }
     if (composable.data) {
       if (isFunction(composable.data)) {
         const dataObject = (composable.data as Function)()

--- a/src/types-handling.ts
+++ b/src/types-handling.ts
@@ -7,6 +7,7 @@ import {
   ComponentOptionsWithoutProps,
   ComputedOptions,
   ComputedRef,
+  ExtractPropTypes,
   Ref,
   UnwrapRef,
 } from 'vue'
@@ -28,7 +29,7 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {}
 export type ArrayToPropsObject<T extends readonly string[]> = {
   readonly [P in T[number]]: any
 }
-
+/*
 type ConstructorToPrimitive<T> = T extends ArrayConstructor
   ? any[]
   : T extends ObjectConstructor
@@ -42,7 +43,7 @@ type ConstructorToPrimitive<T> = T extends ArrayConstructor
   : T extends DateConstructor
   ? Date
   : T
-
+*/
 export type ComposableContext<Props, Data, Computed, Methods, Args> = (Props extends string
   ? /**
      * ["title"] -> { title: ArgType | any }
@@ -53,9 +54,8 @@ export type ComposableContext<Props, Data, Computed, Methods, Args> = (Props ext
   : /**
      * { title: Number } -> { title: Number | undefined }
      */
-    {
-      readonly [P in keyof Props]: ConstructorToPrimitive<Props[P]> | undefined
-    }) &
+
+    Prettify<Readonly<ExtractPropTypes<Props>>>) &
   {
     readonly [K in keyof Methods]: Methods[K]
   } &

--- a/src/types-handling.ts
+++ b/src/types-handling.ts
@@ -29,21 +29,7 @@ export type Prettify<T> = { [K in keyof T]: T[K] } & {}
 export type ArrayToPropsObject<T extends readonly string[]> = {
   readonly [P in T[number]]: any
 }
-/*
-type ConstructorToPrimitive<T> = T extends ArrayConstructor
-  ? any[]
-  : T extends ObjectConstructor
-  ? Record<string, any>
-  : T extends StringConstructor
-  ? string
-  : T extends NumberConstructor
-  ? number
-  : T extends BooleanConstructor
-  ? boolean
-  : T extends DateConstructor
-  ? Date
-  : T
-*/
+
 export type ComposableContext<Props, Data, Computed, Methods, Args> = (Props extends string
   ? /**
      * ["title"] -> { title: ArgType | any }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
 import { PropType } from 'vue'
+
 type Data = Record<string, unknown>
 
 type DefaultFactory<T> = (props: Data) => T | null | undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable valid-typeof */
+
 import { PropType } from 'vue'
 
 type Data = Record<string, unknown>
@@ -7,7 +9,7 @@ type Data = Record<string, unknown>
 type DefaultFactory<T> = (props: Data) => T | null | undefined
 
 interface PropOptions<T = any, D = T> {
-  type?: PropType<T> | true | null
+  type?: PropType<T> | true
   required?: boolean
   default?: D | DefaultFactory<D> | null | undefined | object
   validator?(value: unknown, props: Data): boolean
@@ -20,9 +22,10 @@ export const { isArray } = Array
 export function isPropOptions(value: any): value is PropOptions {
   return (
     typeof value === 'object' &&
-    (value.type === undefined || typeof value.type === 'function' || value.type === true || value.type === null) &&
+    (value.type === undefined || typeof value.type === 'function' || value.type === true) &&
     (value.required === undefined || typeof value.required === 'boolean') &&
-    (value.default === undefined || typeof value.default === 'function' || typeof value.default === 'object') &&
-    (value.validator === undefined || typeof value.validator === 'function')
+    (value.default === undefined ||
+      typeof value.default === 'function' ||
+      typeof value.default === value.type.name.toLowerCase())
   )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,6 @@ export function isPropOptions(value: any): value is PropOptions {
     (value.required === undefined || typeof value.required === 'boolean') &&
     (value.default === undefined ||
       typeof value.default === 'function' ||
-      typeof value.default === value.type.name.toLowerCase())
+      (value.type !== true && typeof value.default === value.type.name.toLowerCase()))
   )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,26 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { PropType } from 'vue'
+type Data = Record<string, unknown>
+
+type DefaultFactory<T> = (props: Data) => T | null | undefined
+
+interface PropOptions<T = any, D = T> {
+  type?: PropType<T> | true | null
+  required?: boolean
+  default?: D | DefaultFactory<D> | null | undefined | object
+  validator?(value: unknown, props: Data): boolean
+}
+
 export const isFunction = (val: unknown): val is Function => typeof val === 'function'
 
 export const { isArray } = Array
+
+export function isPropOptions(value: any): value is PropOptions {
+  return (
+    typeof value === 'object' &&
+    (value.type === undefined || typeof value.type === 'function' || value.type === true || value.type === null) &&
+    (value.required === undefined || typeof value.required === 'boolean') &&
+    (value.default === undefined || typeof value.default === 'function' || typeof value.default === 'object') &&
+    (value.validator === undefined || typeof value.validator === 'function')
+  )
+}

--- a/test/vuelve.test.ts
+++ b/test/vuelve.test.ts
@@ -225,6 +225,125 @@ describe('vuelve', () => {
       new TypeError('Invalid prop: type check failed for prop "title". Expected String, got Number')
     )
   })
+  it('throws an error when prop of incorrect type is provided', async () => {
+    const composable = vuelve({
+      props: {
+        title: {
+          type: String,
+          required: true,
+        },
+      },
+      data() {
+        return { count: 0 }
+      },
+      computed: {
+        titleWithCount() {
+          return `${this.title} ${this.count.value}`
+        },
+      },
+    })
+
+    expect(() => composable(1)).toThrow(
+      new TypeError('Invalid prop: type check failed for prop "title". Expected String, got Number')
+    )
+  })
+
+  it('throws an error when required prop is not provided', async () => {
+    const composable = vuelve({
+      props: {
+        title: {
+          type: String,
+          required: true,
+        },
+        description: {
+          type: String,
+          required: true,
+        },
+      },
+      data() {
+        return { count: 0 }
+      },
+      computed: {
+        titleWithCount() {
+          return `${this.title} ${this.count.value}`
+        },
+      },
+    })
+
+    expect(() => composable('new title')).toThrow(new Error('description is required but not provided.'))
+  })
+  it('successfully handles prop of correct type with dynamic value', async () => {
+    const composable = vuelve({
+      props: {
+        title: {
+          type: true,
+        },
+      },
+      data() {
+        return { count: 0 }
+      },
+      computed: {
+        titleWithCount() {
+          return `${this.title} ${this.count.value}`
+        },
+      },
+    })
+
+    const component = defineComponent({
+      props: {
+        title: String,
+      },
+      setup(props) {
+        const { titleWithCount } = composable(props.title)
+        return { titleWithCount }
+      },
+      template: '<div>{{ titleWithCount }}</div>',
+    })
+
+    const wrapper = mount(component, {
+      props: {
+        title: 'Count:',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Count: 0')
+  })
+  it('successfully handles props with default values', async () => {
+    const composable = vuelve({
+      props: {
+        title: {
+          type: String,
+          required: false,
+          default: () => 'Count',
+        },
+        secondTitle: {
+          type: String,
+          required: false,
+          default: 'Click:',
+        },
+      },
+      data() {
+        return { count: 0 }
+      },
+      computed: {
+        titleWithCount() {
+          return `${this.title} and ${this.secondTitle} ${this.count.value}`
+        },
+      },
+    })
+
+    const component = defineComponent({
+      setup() {
+        const { titleWithCount } = composable()
+        return { titleWithCount }
+      },
+      template: '<div>{{ titleWithCount }}</div>',
+    })
+
+    const wrapper = mount(component)
+
+    expect(wrapper.text()).toContain('Count and Click: 0')
+  })
 
   it('successfully handles props of correct type', async () => {
     const composable = vuelve({


### PR DESCRIPTION
## Description

This pull request extends the type of props according to the whole prop types of Vue 3. It introduces improvements to handle prop types more accurately and enhances the type checking mechanism for props in vuelve.

### Changes Made:

- Extended the type of props to cover the entire prop types available in Vue 3.
- Refactored the type handling logic to ensure accurate type checking for props.
- Added support for extracting prop types using `ExtractPropTypes` from Vue 3.
- Implemented checks for prop options to handle required props and default values correctly.
- Updated the `vuelve` function to provide better type inference for props.
- Improved error handling for invalid prop types during setup.
